### PR TITLE
Fix type error

### DIFF
--- a/src/utils/getPredominantColorFromImgURL.ts
+++ b/src/utils/getPredominantColorFromImgURL.ts
@@ -1,6 +1,6 @@
 import ColorThief from 'colorthief/dist/color-thief.umd.js';
 import { loadImage, formatRGB } from '.';
-import type { ColorFormats, ArrayRGB } from '../types';
+import { ColorFormats, ArrayRGB } from '../types';
 
 export default async function getPredominantColorFromImgURL<
   T extends ColorFormats


### PR DESCRIPTION
TypeScript error in D:/Trabalhos/Spotogether/Web/node_modules/color-thief react/lib/utils/getPredominantColorFromImgURL.d.ts(1,13):
'=' expected.  TS1005

<img src="https://i.imgur.com/fORUOo5.png" />