### PR TITLE
Add HSL options to colorFormats

### DIFF
--- a/src/types/ColorFormats.ts
+++ b/src/types/ColorFormats.ts
@@ -4,5 +4,9 @@
  * `hex` returns a color in hexadecimal format. `#000000`
  *
  * `rgbArray` returns a array of rgb. `[0, 0, 0]`
+ * 
+ * `hslString` returns an hsl string format. `hsl(0, 0, 0)`
+ * 
+ * `hslArray` returns a array of hsl. `[0, 0, 0]`
  */
-export type ColorFormats = 'rgbString' | 'hex' | 'rgbArray';
+export type ColorFormats = 'rgbString' | 'hex' | 'rgbArray' | 'hslString' | 'hslArray';

--- a/src/types/ColorFormats.ts
+++ b/src/types/ColorFormats.ts
@@ -4,9 +4,14 @@
  * `hex` returns a color in hexadecimal format. `#000000`
  *
  * `rgbArray` returns a array of rgb. `[0, 0, 0]`
- * 
+ *
  * `hslString` returns an hsl string format. `hsl(0, 0, 0)`
- * 
+ *
  * `hslArray` returns a array of hsl. `[0, 0, 0]`
  */
-export type ColorFormats = 'rgbString' | 'hex' | 'rgbArray' | 'hslString' | 'hslArray';
+export type ColorFormats =
+  | 'rgbString'
+  | 'hex'
+  | 'rgbArray'
+  | 'hslString'
+  | 'hslArray';

--- a/src/utils/formatRGB.test.ts
+++ b/src/utils/formatRGB.test.ts
@@ -1,6 +1,7 @@
 import formatRGB from './formatRGB';
 
 const rgbArray: [number, number, number] = [230, 102, 34];
+const hslArray: [number, number, number] = [21, 80, 52];
 
 describe('formatRGB', () => {
   test('should return a string of RGB', () => {
@@ -11,5 +12,11 @@ describe('formatRGB', () => {
   });
   test('should return a array of RGB', () => {
     expect(formatRGB(rgbArray, 'rgbArray')).toBe(rgbArray);
+  });
+  test('should return a array of HSL', () => {
+    expect(formatRGB(rgbArray, 'hslArray')).toStrictEqual(hslArray);
+  });
+  test('should return a string of hsl', () => {
+    expect(formatRGB(rgbArray, 'hslString')).toBe('hsl(21, 80%, 52%)');
   });
 });

--- a/src/utils/formatRGB.ts
+++ b/src/utils/formatRGB.ts
@@ -16,7 +16,7 @@ export default function formatRGB<T extends ColorFormats>(
     hex: () => rgbToHex(...arrayRGB),
     rgbArray: () => arrayRGB,
     hslString: () => hslStringfy(rgbToHSL(...arrayRGB)),
-    hslArray: () => rgbToHSL(...arrayRGB),
+    hslArray: () => rgbToHSL(...arrayRGB)
   };
 
   return responses[format]();

--- a/src/utils/formatRGB.ts
+++ b/src/utils/formatRGB.ts
@@ -1,5 +1,7 @@
 import rgbStringfy from './rgbStringfy';
+import hslStringfy from './hslStringfy';
 import rgbToHex from './rgbToHex';
+import rgbToHSL from './rgbToHSL';
 import type { ColorFormats, ArrayRGB } from '../types';
 
 /**
@@ -12,7 +14,9 @@ export default function formatRGB<T extends ColorFormats>(
   const responses: { [key in ColorFormats]: () => any } = {
     rgbString: () => rgbStringfy(...arrayRGB),
     hex: () => rgbToHex(...arrayRGB),
-    rgbArray: () => arrayRGB
+    rgbArray: () => arrayRGB,
+    hslString: () => hslStringfy(rgbToHSL(...arrayRGB)),
+    hslArray: () => rgbToHSL(...arrayRGB),
   };
 
   return responses[format]();

--- a/src/utils/hslStringfy.test.ts
+++ b/src/utils/hslStringfy.test.ts
@@ -1,0 +1,9 @@
+import hslStringfy from './hslStringfy';
+
+describe('hslStringfy', () => {
+  test('should return a right string of HSL', () => {
+    const hslArray = [230, 102, 34];
+    const hsl = hslStringfy(hslArray[0], hslArray[1], hslArray[2]);
+    expect(hsl).toBe('hsl(21, 80%, 52%)');
+  });
+});

--- a/src/utils/hslStringfy.test.ts
+++ b/src/utils/hslStringfy.test.ts
@@ -2,8 +2,8 @@ import hslStringfy from './hslStringfy';
 
 describe('hslStringfy', () => {
   test('should return a right string of HSL', () => {
-    const hslArray = [230, 102, 34];
-    const hsl = hslStringfy(hslArray[0], hslArray[1], hslArray[2]);
+    const hslArray = [21, 80, 52];
+    const hsl = hslStringfy(hslArray);
     expect(hsl).toBe('hsl(21, 80%, 52%)');
   });
 });

--- a/src/utils/hslStringfy.ts
+++ b/src/utils/hslStringfy.ts
@@ -1,0 +1,6 @@
+/**
+ * Put HSL into a string
+ */
+export default function hslStringfy(h: number, s: number, l: number): string {
+  return `hsl(${r}, ${g}%, ${b}%)`;
+}

--- a/src/utils/hslStringfy.ts
+++ b/src/utils/hslStringfy.ts
@@ -1,6 +1,6 @@
 /**
  * Put HSL into a string
  */
-export default function hslStringfy(h: number, s: number, l: number): string {
-  return `hsl(${h}, ${s}%, ${l}%)`;
+export default function hslStringfy(hsl: number[]): string {
+  return `hsl(${hsl[0]}, ${hsl[1]}%, ${hsl[2]}%)`;
 }

--- a/src/utils/hslStringfy.ts
+++ b/src/utils/hslStringfy.ts
@@ -2,5 +2,5 @@
  * Put HSL into a string
  */
 export default function hslStringfy(h: number, s: number, l: number): string {
-  return `hsl(${r}, ${g}%, ${b}%)`;
+  return `hsl(${h}, ${s}%, ${l}%)`;
 }

--- a/src/utils/rgbToHSL.test.ts
+++ b/src/utils/rgbToHSL.test.ts
@@ -4,6 +4,6 @@ describe('rgbToHSL', () => {
   test('should convert rgb to hsl correctly', () => {
     const rgbArray = [230, 102, 34];
     const hsl = rgbToHSL(rgbArray[0], rgbArray[1], rgbArray[2]);
-    expect(hsl).toBe([21, 80, 52]);
+    expect(hsl).toStrictEqual([21, 80, 52]);
   });
 });

--- a/src/utils/rgbToHSL.test.ts
+++ b/src/utils/rgbToHSL.test.ts
@@ -1,0 +1,9 @@
+import rgbToHSL from './rgbToHSL';
+
+describe('rgbToHSL', () => {
+  test('should convert rgb to hsl correctly', () => {
+    const rgbArray = [230, 102, 34];
+    const hsl = rgbToHSL(rgbArray[0], rgbArray[1], rgbArray[2]);
+    expect(hsl).toBe([21, 80, 52]);
+  });
+});

--- a/src/utils/rgbToHSL.ts
+++ b/src/utils/rgbToHSL.ts
@@ -2,28 +2,43 @@
  * Transform RGB to HSL
  */
 export default function rgbToHSL(r: number, g: number, b: number): number[] {
-  const _r = r / 255;
-  const _g = g / 255;
-  const _b = b / 255;
-  const max = Math.max(_r, _g, _b);
-  const min = Math.min(_r, _g, _b);
+  // Make r, g, and b fractions of 1
+  r /= 255;
+  g /= 255;
+  b /= 255;
+
+  // Find greatest and smallest channel values
+  const cmin = Math.min(r, g, b);
+  const cmax = Math.max(r, g, b);
+  const delta = cmax - cmin;
   let h = 0;
   let s = 0;
-  const v = max;
-  if (max != min) {
-    const delta = max - min;
-    s = delta / max;
-    switch (max) {
-      case _r:
-        h = (_g - _b) / delta + (g < b ? 6 : 0);
-        break;
-      case _g:
-        h = (_b - _r) / delta + 2;
-        break;
-      case _b:
-        h = (_r - _g) / delta + 4;
-        break;
-    }
-  }
-  return [Math.round(h * 60), Math.round(s * 100), Math.round(v * 100)];
+  let l = 0;
+
+  // Calculate hue
+  // No difference
+  if (delta == 0) h = 0;
+  // Red is max
+  else if (cmax == r) h = ((g - b) / delta) % 6;
+  // Green is max
+  else if (cmax == g) h = (b - r) / delta + 2;
+  // Blue is max
+  else h = (r - g) / delta + 4;
+
+  h = Math.round(h * 60);
+
+  // Make negative hues positive behind 360°
+  if (h < 0) h += 360;
+
+  // Calculate lightness
+  l = (cmax + cmin) / 2;
+
+  // Calculate saturation
+  s = delta == 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
+
+  // Multiply l and s by 100
+  s = +(s * 100).toFixed(1);
+  l = +(l * 100).toFixed(1);
+
+  return [Math.round(h), Math.round(s), Math.round(l)];
 }

--- a/src/utils/rgbToHSL.ts
+++ b/src/utils/rgbToHSL.ts
@@ -1,7 +1,7 @@
 /**
- * Transform RGB to HEX
+ * Transform RGB to HSL
  */
-export default function rgbToHSL(r: number, g: number, b: number): string {
+export default function rgbToHSL(r: number, g: number, b: number): number[] {
   const _r = r / 255;
   const _g = g / 255;
   const _b = b / 255;
@@ -9,16 +9,19 @@ export default function rgbToHSL(r: number, g: number, b: number): string {
   const min = Math.min(_r, _g, _b);
   let h = 0;
   let s = 0;
-  let v = max;
+  const v = max;
   if (max != min) {
-    let delta = max - min;
+    const delta = max - min;
     s = delta / max;
     switch (max) {
-      case _r: h = (_g - _b) / delta + (g < b ? 6 : 0);
+      case _r:
+        h = (_g - _b) / delta + (g < b ? 6 : 0);
         break;
-      case _g: h = (_b - _r) / delta + 2;
+      case _g:
+        h = (_b - _r) / delta + 2;
         break;
-      case _b: h = (_r - _g) / delta + 4;
+      case _b:
+        h = (_r - _g) / delta + 4;
         break;
     }
   }

--- a/src/utils/rgbToHSL.ts
+++ b/src/utils/rgbToHSL.ts
@@ -1,0 +1,26 @@
+/**
+ * Transform RGB to HEX
+ */
+export default function rgbToHSL(r: number, g: number, b: number): string {
+  const _r = r / 255;
+  const _g = g / 255;
+  const _b = b / 255;
+  const max = Math.max(_r, _g, _b);
+  const min = Math.min(_r, _g, _b);
+  let h = 0;
+  let s = 0;
+  let v = max;
+  if (max != min) {
+    let delta = max - min;
+    s = delta / max;
+    switch (max) {
+      case _r: h = (_g - _b) / delta + (g < b ? 6 : 0);
+        break;
+      case _g: h = (_b - _r) / delta + 2;
+        break;
+      case _b: h = (_r - _g) / delta + 4;
+        break;
+    }
+  }
+  return [Math.round(h * 60), Math.round(s * 100), Math.round(v * 100)];
+}


### PR DESCRIPTION
I found myself using this repository and needing HSL support for a specific use case, and thought it would be useful to include it in the library by default. 

This is my first contribution to an open source project, so please let me know if there is anything that I should fix or do differently. 